### PR TITLE
Fixes #13

### DIFF
--- a/src/RequestHTML.js
+++ b/src/RequestHTML.js
@@ -1,6 +1,8 @@
 const __request = require("request");
 const __cheerio = require("cheerio");
 
+const TIMEOUT_DURATION_MS = 5000;
+
 class RequestHTML {
   constructor() {
     this.headers = {
@@ -30,18 +32,38 @@ class RequestHTML {
    * Promise that returns the HTML content of a page.
    * Ex: instance.get("https://example.com").then( function (html) ... )
    * @param {String} url of the page to fetch
+   * @param {number=} retries Number of fetch attempts
    * @return {Promise: IncomingMessage if fulfilled} Incoming message object (https://nodejs.org/api/http.html#http_class_http_incomingmessage)
    */
-  get(url) {
-    const options = { url: url, headers: this.headers };
-    return this.__fetchPage(options).then(
+  get(url, retries = 3) {
+    // No more retries, give up
+    if (!retries) return Promise.resolve();
+
+    // Keep track if the fetch was successful (to stop continued retries)
+    let isFetchCompleted = false;
+
+    // Attempt to fetch the url
+    const options = { url, headers: this.headers };
+    const fetchPromise = this.__fetchPage(options).then(
       function(response) {
+        isFetchCompleted = true;
         return response;
       },
       function(err) {
+        isFetchCompleted = true;
         return new Error(err);
       }
     );
+
+    // Timeout promise, in case the fetch takes too long.
+    const timeoutPromise =
+        new Promise((resolve) => setTimeout(resolve, TIMEOUT_DURATION_MS)).then(
+        () => {
+          if (!isFetchCompleted) return this.get(url, --retries);
+        });
+
+    // Race the success or timeout promise, whichever comes first.
+    return Promise.race([fetchPromise, timeoutPromise]);
   }
 }
 


### PR DESCRIPTION
This cl fixes the hanging request problem.

This fix updates the `get` method of RequestHTML, adding logic to
retry 3 times before bailing.

The retry time I added was 5 seconds, which is a generous amount of
time... but its also a random number I pulled from hat.

This cl could be scaled down a bunch by removing the retry logic.